### PR TITLE
Remove '-q --query' flag(s)

### DIFF
--- a/docs/files/configuration.md
+++ b/docs/files/configuration.md
@@ -8,7 +8,7 @@ ways:
 ## Via CLI
 
 ```
-sql-lint --driver="mysql" --host="localhost" --user="root" --password="hunter2" --query="SELECT 1;"
+sql-lint --driver="mysql" --host="localhost" --user="root" --password="hunter2"
 ```
 
 ## Via `config.json`

--- a/docs/files/introduction.md
+++ b/docs/files/introduction.md
@@ -38,12 +38,6 @@ echo "DELETE FROM person;" | sql-lint
 sql-lint -f test-file.sql
 ```
 
-### With a string
-
-```
-sql-lint --query="DELETE FROM person;"
-```
-
 ## Command line options
 
 ### -V --version
@@ -62,15 +56,6 @@ Specifies the file to be linted
 
 ```
 sql-lint --file "test.sql"
-> ...
-```
-
-### -q --query
-
-Specifies an SQL query string to be linted. Note that it must end with a ';'.
-
-```
-sql-lint --query "SELECT * FROM person WHERE name = 'John';"
 > ...
 ```
 
@@ -104,17 +89,17 @@ The output format of `sql-lint`.
  the format unless you have a reason to.
 
  ```
- sql-lint --query "DELETE FROM person;"
-> query:1 [sql-lint: missing-where] DELETE statement missing WHERE clause.
+ echo 'DELETE FROM person;' | sql-lint
+> stdin:1 [sql-lint: missing-where] DELETE statement missing WHERE clause.
  ```
 
 `json` can be used if you wish. Usually this is done for editor
 integration or for consumption via some other service.
 
 ```
-sql-lint --query "DELETE FROM person;" --format json
+echo 'DELETE FROM person;' | sql-lint --format json
 > {
-     "source":"query",
+     "source":"stdin",
      "error":"[sql-lint: missing-where] DELETE statement missing WHERE clause.",
      "line":1
 }
@@ -147,7 +132,6 @@ Usage: sql-lint [options]
 Options:
   -V, --version          output the version number
   -f, --file <path>      The .sql file to lint
-  -q, --query <string>   The query to lint
   -d, --driver <string>  The driver to use, must be one of ['mysql', 'postgres']
   -v, --verbose          Brings back information on the what it's linting and the tokens generated
   --format <string>      The format of the output, can be one of ['simple', 'json'] (default: "simple")

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,6 @@ program
   .version(version)
   .option("-f, --file <path>", "The .sql file to lint")
   .option("--fix [string]", "The .sql string to fix")
-  .option("-q, --query <string>", "The query to lint")
   .option(
     "-d, --driver <string>",
     "The driver to use, must be one of ['mysql', 'postgres']"
@@ -53,11 +52,6 @@ const printer: Printer = new Printer(program.verbose, format);
 const configuration = getConfiguration(file);
 const runner = new CheckerRunner();
 
-if (program.query) {
-  queries = getQueryFromLine(program.query);
-  prefix = "query";
-}
-
 if (program.file) {
   if (!fs.existsSync(program.file) && program.file !== 0) {
     printer.warnAboutFileNotFound(program.file);
@@ -87,7 +81,7 @@ if (program.fix) {
 }
 
 // Read from stdin if no args are supplied
-if (!program.file && !program.query) {
+if (!program.file) {
   queries = getQueryFromLine(fs.readFileSync(0).toString());
   prefix = "stdin";
 }


### PR DESCRIPTION
This simplifies the CLI interface. If people want to lint a fixed string
then they should use the stdin interface
i.e.
```
echo 'DELETE FROM person;' | sql-lint
```