### PR TITLE
Strip multiline comments from templates

### DIFF
--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -3,6 +3,7 @@ import { Line } from "./line";
 import { Query } from "./query";
 import { Keyword } from "../syntax/keywords";
 
+const reMultilineComments = /\/\*[\s\S]+?\*\//g;
 /**
  * Grabs the querie(s) from the --file flag
  */
@@ -52,6 +53,7 @@ export function putContentIntoLines(contents: string): Query[] {
  * 3. Rejoin the lines together as a single string.
  */
 function stripComments(content: string): string {
+  content = content.replace(reMultilineComments, '');
   const contentInLines = content.split(Keyword.Newline);
 
   for (let i = 0; i < contentInLines.length; i++) {

--- a/test/unit/reader/reader.test.ts
+++ b/test/unit/reader/reader.test.ts
@@ -57,3 +57,9 @@ test("We correctly construct lines in a query from a string", () => {
   const actual = getQueryFromLine(input);
   expect(actual).toEqual(expected);
 });
+
+test("We should ignore multiline comments", () => {
+  const input = "/*\n * catpants\n*/DELETE\n FROM \n\n person /*comment */WHERE \n/*\n\n this is useless*/ age > 5;";
+
+  expect(getQueryFromLine(input)).toEqual([this.query]);
+});


### PR DESCRIPTION
This strips multiline comments from files.

This fixes #95.