### PR TITLE
Add support for directory-local config

### DIFF
--- a/docs/files/configuration.md
+++ b/docs/files/configuration.md
@@ -11,13 +11,19 @@ ways:
 sql-lint --driver="mysql" --host="localhost" --user="root" --password="hunter2"
 ```
 
-## Via `config.json`
+## Via File
 
-A configuration file for `sql-lint` can reside in
+`sql-lint` will search the current working directory and its parent directories
+for a configuration file `.sql-lint.json`. This allows you to have
+directory-local configurations for different projects. If no `.sql-lint.json`
+is found, it will fall back to the global configuration file.
+
+A global configuration file for `sql-lint` can reside in
 `~/.config/sql-lint/config.json`.  It follows the [XDG Base Directory
 Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-Specifically, it uses `$HOME/.config`. (You can specify a different path for the
-config with the `--config` flag)
+Specifically, it uses `$HOME/.config`.
+
+You can also manually specify a path for the config with the `--config` flag.
 
 You should put the following in there for more intelligent errors to come through
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as process from "process";
 
 import { CheckerRunner } from "./checker/checkerRunner";
-import { file, getConfiguration } from "./config";
+import { file, getConfiguration, findConfiguration } from "./config";
 import { findByExtension } from "./file";
 import { FormatterFactory } from "./formatter/formatterFactory";
 import { getQueryFromFile, getQueryFromLine } from "./reader/reader";
@@ -48,7 +48,9 @@ import databaseFactory from "./database/databaseFactory";
   const formatterFactory = new FormatterFactory();
   const format = formatterFactory.build(program.format);
   const printer: Printer = new Printer(program.verbose, format);
-  const configuration = getConfiguration(program.config || file);
+  const configuration = (program.config)
+    ? getConfiguration(program.config)
+    : findConfiguration();
   const runner = new CheckerRunner();
   const programFile = program.args[0];
 
@@ -92,7 +94,11 @@ import databaseFactory from "./database/databaseFactory";
   let db: any;
 
   if (configuration === null) {
-    printer.warnAboutNoConfiguration(file);
+    if (program.config) {
+      printer.warnAboutFileNotFound(program.config);
+    } else {
+      printer.warnAboutNoConfiguration(file);
+    }
   }
 
   const driver = program.driver || configuration?.driver || "mysql";

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import * as os from "os";
 import * as path from "path";
 import * as process from "process";
 
-export const file_local = ".sql-lint.json";
+export const fileLocal = ".sql-lint.json";
 export const file = `${os.homedir}/.config/sql-lint/config.json`;
 
 export function getConfiguration(config: string) {
@@ -16,7 +16,7 @@ export function getConfiguration(config: string) {
 export function findConfiguration() {
   var dir = process.cwd();
   while (dir != "/") {
-    var config = path.join([dir, file_local]);
+    var config = path.join([dir, fileLocal]);
     if (fs.existsSync(config)) {
       return JSON.parse(fs.readFileSync(config, "utf8"));
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,9 @@ export function getConfiguration(config: string) {
 }
 
 export function findConfiguration() {
-  var dir = process.cwd();
-  while (dir != "/") {
-    var config = path.join([dir, fileLocal]);
+  let dir = process.cwd();
+  while (dir !== "/") {
+    const config = path.join(dir, fileLocal);
     if (fs.existsSync(config)) {
       return JSON.parse(fs.readFileSync(config, "utf8"));
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,31 @@
 import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
+import * as process from "process";
 
+export const file_local = ".sql-lint.json";
 export const file = `${os.homedir}/.config/sql-lint/config.json`;
 
 export function getConfiguration(config: string) {
   if (fs.existsSync(config)) {
     return JSON.parse(fs.readFileSync(config, "utf8"));
   }
+  return null;
+}
+
+export function findConfiguration() {
+  var dir = process.cwd();
+  while (dir != "/") {
+    var config = path.join([dir, file_local]);
+    if (fs.existsSync(config)) {
+      return JSON.parse(fs.readFileSync(config, "utf8"));
+    }
+    dir = path.dirname(dir);
+  }
+
+  if (fs.existsSync(file)) {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  }
+
   return null;
 }


### PR DESCRIPTION
This PR adds support for a directory-local config (as common in such tools), to make working with different per-project configs more convenient.

If no config-file was passed to the CLI, it will now search from the current working directory upwards for a file called `.sql-lint.json`. If none is found, it will fall back to the "global" config at `$HOME/.config/sql-lint/config.json`.

This addition was also documented in `docs/files/configuration.md`.

**PS:**

I had trouble setting up a working development environment, so I could not test the modifications. While the modifications are pretty basic/simple, you might want to test them yourself before merging the PR (in case you'd accept the PR).

Also, I did not push the rebuilt documentation, as some unexpected files were affected by the rebuild.