### PR TITLE
fix: Resolve promise from lintQuery

### DIFF
--- a/src/checker/checkerRunner.ts
+++ b/src/checker/checkerRunner.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { CheckFactory } from "./checkFactory";
 import { Query } from "../reader/query";
-import IDatabase from "../database/interface";
+import IDatabase, { sqlError } from "../database/interface";
 import { Printer } from "../printer";
 import { categorise, tokenise } from "../lexer/lexer";
 import { MySqlError } from "../barrel/checks";
@@ -81,9 +81,13 @@ class CheckerRunner {
             database &&
             checker.appliesTo.includes(category)
           ) {
-            const results = await database.lintQuery(content);
-            const sqlChecker = new MySqlError(results);
-            printer.printCheck(sqlChecker, tokenised, prefix);
+            const results: sqlError | null = await database.lintQuery(content);
+
+            // Only `printCheck` if there was an error
+            if (results !== null) {
+              const sqlChecker = new MySqlError(results);
+              printer.printCheck(sqlChecker, tokenised, prefix);
+            }
           }
         }
       }

--- a/src/database/mySqlDatabase.ts
+++ b/src/database/mySqlDatabase.ts
@@ -18,7 +18,11 @@ export default class MySqlDatabase implements IDatabase {
       this.connection.query(`EXPLAIN ${query}`, (err) => {
         if (err) {
           resolve((err as unknown) as sqlError);
+          return;
         }
+
+        // resolve with null if there is no error.
+        resolve(null);
       });
     });
   }

--- a/src/database/postgresDatabase.ts
+++ b/src/database/postgresDatabase.ts
@@ -21,7 +21,11 @@ export default class PostgresDatabase implements IDatabase {
             code: err.name,
             sqlMessage: err.message,
           });
+          return;
         }
+
+        // resolve with null if there is no error.
+        resolve(null);
       });
     });
   }

--- a/test/unit/database/postgresDatabaseNoError.test.ts
+++ b/test/unit/database/postgresDatabaseNoError.test.ts
@@ -1,0 +1,28 @@
+import PostgresDatabase from "../../../src/database/postgresDatabase";
+
+jest.mock("pg", () => {
+  const mock = {
+    Pool: function (config) {
+      expect(config).toEqual({
+        host: "localhost",
+        user: "user",
+        password: "password",
+        port: 5432,
+      });
+      return mock;
+    },
+    query: (query, callback) => {
+
+      callback(undefined, {});
+    },
+    end: () => true,
+  };
+  return mock;
+});
+
+test("lintQuery is null when there are no errors", async () => {
+  const db = new PostgresDatabase("localhost", "user", "password", 5432);
+  const sql = "SELECT some_column FROM some_table WHERE id = 1";
+
+  expect(await db.lintQuery(sql)).toBeNull();
+});

--- a/test/unit/mainNoError.test.ts
+++ b/test/unit/mainNoError.test.ts
@@ -1,0 +1,64 @@
+import sqlLint from "../../src/main";
+
+jest.mock("mysql2", () => {
+  const mock = {
+    createConnection: (config) => {
+      expect(config).toEqual({
+        port: 5000,
+        user: "user",
+        host: "localhost",
+        password: "password",
+      });
+      return mock;
+    },
+    query: (_, callback) => {
+      callback(undefined, {});
+    },
+    end: () => true,
+  };
+  return mock;
+});
+
+test("no errors when mysql DB query runs successfully", async () => {
+  const params = {
+    port: 5000,
+    user: "user",
+    host: "localhost",
+    password: "password",
+    sql: "SELECT some_column FROM my_database.some_table;",
+  };
+
+  expect(await sqlLint(params)).toMatchObject([]);
+});
+
+jest.mock("pg", () => {
+  const mock = {
+    Pool: function (config) {
+      expect(config).toEqual({
+        host: "localhost",
+        user: "user",
+        password: "password",
+        port: 5432,
+      });
+      return mock;
+    },
+    query: (_, callback) => {
+      callback(undefined, {});
+    },
+    end: () => {},
+  };
+  return mock;
+});
+
+test("no errors when postgres DB query runs successfully", async () => {
+  const params = {
+    driver: "postgres",
+    host: "localhost",
+    password: "password",
+    port: 5432,
+    sql: "SELECT some_column FROM my_database.some_table;",
+    user: "user",
+  };
+
+  expect(await sqlLint(params)).toMatchObject([]);
+});


### PR DESCRIPTION
`lintQuery` in Both postgres and mysql returns a promise that never gets
resolved unless there is an error causing `await
database.lintQuery(content);` to hang forever. This PR resolves with a
null when there is no error.