### PR TITLE
Fix ignore-errors not being respected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "sql-lint",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.18",
+            "name": "sql-lint",
+            "version": "0.0.19",
             "license": "MIT",
             "dependencies": {
                 "@types/moo": "^0.5.3",

--- a/src/checker/checkerRunner.ts
+++ b/src/checker/checkerRunner.ts
@@ -34,9 +34,11 @@ class CheckerRunner {
         // .js - There seems to be a discrepancy with filenames when using the compiled
         //       version of sql-lint (./dist/src/main.js). They are finding checks and
         //       including the .js. We ignore those too
-        return !ignoredChecks.includes(item)
-          && !item.endsWith(".js")
-          && !item.endsWith(".d");
+        return (
+          !ignoredChecks.includes(item) &&
+          !item.endsWith(".js") &&
+          !item.endsWith(".d")
+        );
       });
 
     const driverSpecificChecks = fs
@@ -66,6 +68,11 @@ class CheckerRunner {
 
         for (const check of checks) {
           const checker = factory.build(check);
+
+          // Don't print out errors that should be ignored
+          if (omittedErrors.includes(checker.getName())) {
+            continue;
+          }
 
           // Simple checks
           if (

--- a/src/checker/checks/any/tableNotFound.ts
+++ b/src/checker/checks/any/tableNotFound.ts
@@ -4,8 +4,9 @@ import { CheckerResult } from "../../checkerResult";
 import { IChecker } from "../../interface";
 import { Types } from "../../../lexer/types";
 import { sprintf } from "sprintf-js";
+import { Check } from "../../check";
 
-class TableNotFound implements IChecker {
+class TableNotFound extends Check implements IChecker {
   public message = "Table '%s' does not exist in database '%s'.";
   public additionalInformation = "";
   public appliesTo = ["select", "create", "update", "drop", "insert"];
@@ -13,6 +14,7 @@ class TableNotFound implements IChecker {
 
   public tables: string[];
   constructor(tables: any[]) {
+    super();
     this.tables = this.cleanTables(tables);
   }
 

--- a/src/checker/checks/generic/sqlError.ts
+++ b/src/checker/checks/generic/sqlError.ts
@@ -28,6 +28,10 @@ export default class SqlError implements IChecker {
     return new CheckerResult(0, "");
   }
 
+  public getName(): string {
+      return '';
+  }
+
   private concatErrorObject(error: any) {
     return `[${error.code}] ${error.sqlMessage}`;
   }

--- a/src/checker/interface.ts
+++ b/src/checker/interface.ts
@@ -5,6 +5,7 @@ interface IChecker {
   additionalInformation: string;
   requiresConnection: boolean;
   appliesTo: string[];
+  getName(): string;
   check(query: Query): any;
 }
 

--- a/src/checker/nullChecker.ts
+++ b/src/checker/nullChecker.ts
@@ -1,8 +1,9 @@
 import { Query } from "../reader/query";
 import { CheckerResult } from "./checkerResult";
 import { IChecker } from "./interface";
+import { Check } from "./check";
 
-class NullChecker implements IChecker {
+class NullChecker extends Check implements IChecker {
   public message: string = "";
   public requiresConnection = false;
   public appliesTo = [];

--- a/test/test-files/trailing-whitespace-errors.sql
+++ b/test/test-files/trailing-whitespace-errors.sql
@@ -1,0 +1,18 @@
+-- To see these errors in vim, you need the patch:
+-- https://github.com/joereynolds/sql-lint/issues/30
+-- failing that you can do `:!sql-lint %`
+
+-- Valid Queries (These should not display any errors)
+ALTER TABLE test;
+CREATE TABLE person;
+DROP TABLE test;
+TRUNCATE TABLE person;
+DELETE
+FROM 
+PERSON  
+WHERE something;
+
+-- [sql-lint: trailing-whitespace]
+DELETE 
+FROM 
+PERSON WHERE 1=1;


### PR DESCRIPTION
Even though this was a config option, it was never actually honoured for
some reason. Currently this option can only be done via config.json but
it'd be good if we could specify it as a command line option too i.e.
```
sql-lint --ignore-errors=missing-where,trailing-whitespace
```

This would also allow us to write some integration tests against it
because currently there aren't any tests against this :(