### PR TITLE
Add `--ignore-errors` option

### DIFF
--- a/docs/files/configuration.md
+++ b/docs/files/configuration.md
@@ -87,6 +87,19 @@ documentation](./checks.md)
 
 You cannot skip checks that are returned from the DB server itself, only the checks built into `sql-lint`.
 
+Note that this option is also available as a flag on the cli.
+i.e.
+
+```
+sql-lint --ignore-errors=trailing-whitespace some-sql-file.sql
+```
+
+Multiple errors can be comma separated:
+
+```
+sql-lint --ignore-errors=trailing-whitespace,missing-where,hungarian-notation some-sql-file.sql
+```
+
 ### Example configuration
 
 The below configuration contains every option available.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,8 @@ import databaseFactory from "./database/databaseFactory";
 (async () => {
   program
     .version(version)
-    .option("--fix [string]", "The .sql string to fix")
+    .description("Lint sql files and stdin for errors, oddities, and bad practices.")
+    .option("--fix [string]", "The .sql string to fix (experimental and alpha)")
     .option(
       "-d, --driver <string>",
       "The driver to use, must be one of ['mysql', 'postgres']"
@@ -33,11 +34,12 @@ import databaseFactory from "./database/databaseFactory";
       "The format of the output, can be one of ['simple', 'json']",
       "simple"
     )
-    .option("--host <string>", "The host for the connection")
-    .option("--user <string>", "The user for the connection")
-    .option("--password <string>", "The password for the connection")
-    .option("--port <string>", "The port for the connection")
+    .option("--host <string>", "The host for the database connection")
+    .option("--user <string>", "The user for the database connection")
+    .option("--password <string>", "The password for the database connection")
+    .option("--port <string>", "The port for the database connection")
     .option("--config <string>", "The path to the configuration file")
+    .requiredOption("--ignore-errors <string...>", "The errors to ignore (comma separated)")
     .parse(process.argv);
 
   let queries: Query[] = [];
@@ -77,9 +79,14 @@ import databaseFactory from "./database/databaseFactory";
     prefix = "stdin";
   }
 
+
   let omittedErrors: string[] = [];
   if (configuration !== null && "ignore-errors" in configuration) {
     omittedErrors = configuration["ignore-errors"] || [];
+  }
+
+  if (program.ignoreErrors) {
+      omittedErrors = program.ignoreErrors.split(',')
   }
 
   let db: any;


### PR DESCRIPTION
Previously, the `ignore-errors` config option was only allowed to be
defined within `config.json`. It makes sense that this should be
mirrored into the cli as an option.

Some examples of usage:

```
sql-lint --ignore-errors=trailing-whitespace some-sql-file.sql
```

Multiple errors can be comma separated:

```
sql-lint --ignore-errors=trailing-whitespace,missing-where,hungarian-notation some-sql-file.sql
```