### PR TITLE
Display file location for uncategorisable queries

### DIFF
--- a/src/checker/checkerRunner.ts
+++ b/src/checker/checkerRunner.ts
@@ -60,11 +60,12 @@ class CheckerRunner {
       if (content) {
         const category = categorise(content);
 
+        const tokenised: Query = tokenise(query);
+
         if (!category) {
-          printer.warnAboutUncategoriseableQuery(content);
+          printer.warnAboutUncategoriseableQuery(content, tokenised, prefix);
         }
 
-        const tokenised: Query = tokenise(query);
 
         for (const check of checks) {
           const checker = factory.build(check);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -63,16 +63,18 @@ class Printer {
     console.log(fixed);
   }
 
-  public warnAboutUncategoriseableQuery(content: string) {
+  public warnAboutUncategoriseableQuery(content: string, tokenised: Query, prefix: string) {
     const title = "Unable to lint query";
     const url = encodeURI(
       `https://github.com/joereynolds/sql-lint/issues/new?title=${title}&body=${content}`
     );
 
-    console.log(
-      `sql-lint was unable to lint the following query "${content}".` +
+    const lineNumber = tokenised.lines[0].num;
+
+    const errorMessage = `${prefix}:${lineNumber} sql-lint was unable to lint the following query "${content}".` +
         `This could be a bug with sql-lint. Visit this URL to create a bug report: ${url}`
-    );
+
+    console.log(errorMessage);
   }
 
   public warnAboutNoStdinStream() {


### PR DESCRIPTION
Previously, if a query was uncategorisable, you'd get an error similar
to the following:

```
sql-lint was unable to lint the following query "COMIT;".This could be a bug with sql-lint. Visit this URL to create a bug report: https://github.com/joereynolds/sql-lint/issues/new?title=Unable%20to%20lint%20query&body=;
```

This is okay but does not tell us what file or line that the query is
on. Now the error looks like this:

```
test/test-files/uncategorisable-query.sql:5 sql-lint was unable to lint the following query "COMIT;".This could be a bug with sql-lint. Visit this URL to create a bug report: https://github.com/joereynolds/sql-lint/issues/new?title=Unable%20to%20lint%20query&body=COMMIT%20failed-linting;
```
(Notice the file name and number at the beginning of the error).

It's worth noting this has sort of been bodged in. It would've been nice
to use the `format` classes for this but because they rely on the result
of a check (which we obviously don't have since our query is invalid) we
had to skip it and just log out the string as is.