### PR TITLE
add temp to the list of CREATE statements

### DIFF
--- a/src/lexer/statements/postgres/create.ts
+++ b/src/lexer/statements/postgres/create.ts
@@ -24,6 +24,7 @@ class PostgresCreate implements ILexer {
     "table",
     "tablespace",
     "temporary",
+    "temp",
     "trigger",
     "type",
     "user",


### PR DESCRIPTION
adds `temp` to the list of create statements so that `CREATE TEMP TABLE` is allowed. 

see #252 