### PR TITLE
fix(postgres): use PostgresAlter instead of Alter (mysql) for postgres

### DIFF
--- a/src/barrel/statements.ts
+++ b/src/barrel/statements.ts
@@ -6,6 +6,7 @@ export * from "../lexer/statements/mysql/truncate";
 export * from "../lexer/statements/mysql/use";
 export * from "../lexer/statements/mysql/rename";
 
+export * from "../lexer/statements/postgres/alter";
 export * from "../lexer/statements/postgres/create";
 export * from "../lexer/statements/postgres/drop";
 export * from "../lexer/statements/postgres/select";

--- a/src/checker/checks/postgres/postgresInvalidAlterOption.ts
+++ b/src/checker/checks/postgres/postgresInvalidAlterOption.ts
@@ -1,9 +1,9 @@
 import { IChecker } from "../../interface";
-import { Alter } from "../../../barrel/statements";
+import { PostgresAlter } from "../../../barrel/statements";
 import { InvalidOption } from "../invalidOption";
 
 class PostgresInvalidAlterOption extends InvalidOption implements IChecker {
-  public checker = new Alter();
+  public checker = new PostgresAlter();
   public appliesTo = ["alter"];
 }
 

--- a/src/lexer/statements/postgres/alter.ts
+++ b/src/lexer/statements/postgres/alter.ts
@@ -5,7 +5,7 @@ import { Types } from "../../types";
 import { Keyword } from "../../../syntax/keywords";
 import { Token } from "../../token";
 
-class Alter implements ILexer {
+class PostgresAlter implements ILexer {
   public options: string[] = [
     "column",
     "online",
@@ -47,4 +47,4 @@ class Alter implements ILexer {
   }
 }
 
-export { Alter };
+export { PostgresAlter };

--- a/test/unit/checker/checks/postgres/postgresInvalidAlterOption.test.ts
+++ b/test/unit/checker/checks/postgres/postgresInvalidAlterOption.test.ts
@@ -1,0 +1,27 @@
+import { PostgresInvalidAlterOption } from "../../../../../src/checker/checks/postgres/postgresInvalidAlterOption";
+import { tokenise } from "../../../../../src/lexer/lexer";
+import { putContentIntoLines } from "../../../../../src/reader/reader";
+
+test.each([
+  ["ALTER column;"],
+  ["ALTER online;"],
+  ["ALTER offline;"],
+  ["ALTER ignore;"],
+  ["ALTER database;"],
+  ["ALTER event;"],
+  ["ALTER function;"],
+  ["ALTER procedure;"],
+  ["ALTER sequence;"],
+  ["ALTER server;"],
+  ["ALTER table;"],
+  ["ALTER tablespace;"],
+  ["ALTER view;"],
+])("it does not error about valid ALTER options", (query) => {
+  const checker = new PostgresInvalidAlterOption();
+
+  const queryObj = putContentIntoLines(query);
+  const tokenised = tokenise(queryObj[0]);
+
+  const actual = checker.check(tokenised);
+  expect(actual.content).toBeFalsy();
+});


### PR DESCRIPTION
Use `lexer/statements/postgres/alter`
(previously: `Alter`, new: `PostgresAlter`)
instead of `lexer/statements/mysql/alter` (`Alter`).

Add PostgresAlter to exports at statements.

Add test case for postgres-invalid-alter-option.

Without the changes, the test failed for option `sequence` introduced by PR #204.

Relates-to: PR #204