### PR TITLE
feat(postgres): support ALTER DEFAULT PRIVILEGES

### DIFF
--- a/src/lexer/statements/postgres/alter.ts
+++ b/src/lexer/statements/postgres/alter.ts
@@ -12,6 +12,7 @@ class Alter implements ILexer {
     "offline",
     "ignore",
     "database",
+    "default",
     "event",
     "function",
     "procedure",


### PR DESCRIPTION
Currently, postgres-invalid-alter-option will fail for the valid statement `ALTER DEFAULT PRIVILEGES ...`.

https://www.postgresql.org/docs/16/sql-alterdefaultprivileges.html

Relates-to: PR #258