### PR TITLE
fix(mysql): Added temporary to the list of DROP statements

### DIFF
--- a/src/lexer/statements/mysql/drop.ts
+++ b/src/lexer/statements/mysql/drop.ts
@@ -16,6 +16,7 @@ class Drop implements ILexer {
     "schema",
     "server",
     "table",
+    "temporary",
     "view",
     "tablespace",
     "trigger",


### PR DESCRIPTION
Adds temporary to the list of drop statements so that `DROP TEMPORARY TABLE` is allowed.