### PR TITLE
Fix semicolons in strings

### DIFF
--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -21,12 +21,33 @@ export function putContentIntoLines(contents: string): Query[] {
 
   contents = stripComments(contents);
 
-  for (let i = 0; i < contents.length; i++) {
-    if (!skipChars.includes(contents[i])) {
-      currentQueryContent += contents[i];
+  let currentQuote: string | null = null;
+  let escape = false;
+
+  for (const char of contents) {
+    // \" and \' should be skipped
+    if (char === "\\") {
+      escape = true;
+      currentQueryContent += char;
+      continue;
+    }
+    
+    if (escape) {
+      escape = false;
+      currentQueryContent += char;
+      continue;
     }
 
-    if (contents[i] === Keyword.Newline) {
+    // Toggle string state
+    if (char === "'" || char === "\"") {
+      currentQuote = currentQuote === char ? null : char;
+    }
+
+    if (!skipChars.includes(char)) {
+      currentQueryContent += char;
+    }
+
+    if (char === Keyword.Newline) {
       if (currentQueryContent.length > 0) {
         query.lines.push(new Line(currentQueryContent, lineNumber));
       }
@@ -34,7 +55,7 @@ export function putContentIntoLines(contents: string): Query[] {
       lineNumber++;
     }
 
-    if (contents[i] === ";") {
+    if (char === ";" && currentQuote === null) {
       if (currentQueryContent.length > 0) {
         query.lines.push(new Line(currentQueryContent, lineNumber));
       }

--- a/src/reader/reader.ts
+++ b/src/reader/reader.ts
@@ -40,7 +40,12 @@ export function putContentIntoLines(contents: string): Query[] {
 
     // Toggle string state
     if (char === "'" || char === "\"") {
-      currentQuote = currentQuote === char ? null : char;
+      if (currentQuote === null) {
+        currentQuote = char;
+      } else if (currentQuote === char) {
+        currentQuote = null;
+      }
+      // If currentQuote is not null and doesn't match char, do nothing.
     }
 
     if (!skipChars.includes(char)) {

--- a/test/unit/reader/reader.test.ts
+++ b/test/unit/reader/reader.test.ts
@@ -73,3 +73,28 @@ test("We should ignore multiline comments", () => {
   const query = getTestQuery()
   expect(getQueryFromLine(input)).toEqual([query]);
 });
+
+test("Semicolons inside string literals do not split queries", () => {
+  const input =
+    "INSERT INTO table (col) VALUES ('hello; world'); SELECT * FROM table;";
+  const queries = getQueryFromLine(input);
+  expect(queries).toHaveLength(2);
+  expect(queries[0].getContent()).toEqual(
+    "INSERT INTO table (col) VALUES ('hello; world');"
+  );
+  expect(queries[1].getContent()).toEqual(" SELECT * FROM table;");
+});
+
+test("Escaped quotes and single quote in double quotes do not split queries", () => {
+  const input =
+    "INSERT INTO table (col) VALUES ('It\\'s a test; with escaped quote'); " +
+    "INSERT INTO table (col) VALUES (\"This string contains a 'single quote' and ; semicolon inside\");";
+  const queries = getQueryFromLine(input);
+  expect(queries).toHaveLength(2);
+  expect(queries[0].getContent()).toEqual(
+    "INSERT INTO table (col) VALUES ('It\\'s a test; with escaped quote');"
+  );
+  expect(queries[1].getContent()).toEqual(
+    " INSERT INTO table (col) VALUES (\"This string contains a 'single quote' and ; semicolon inside\");"
+  );
+});


### PR DESCRIPTION
Simply fixes #176.
Semicolons are now skipped if in strings.
Strings are started and ended by " or ' if not escaped,
they must be ended by the same character as they were started by.

I also changed the loop to a `for of` loop for better clarity and less variable clutter.