### PR TITLE
Add support for PostgreSQL DO statements

### DIFF
--- a/src/barrel/statements.ts
+++ b/src/barrel/statements.ts
@@ -8,6 +8,7 @@ export * from "../lexer/statements/mysql/rename";
 
 export * from "../lexer/statements/postgres/alter";
 export * from "../lexer/statements/postgres/create";
+export * from "../lexer/statements/postgres/do";
 export * from "../lexer/statements/postgres/drop";
 export * from "../lexer/statements/postgres/select";
 export * from "../lexer/statements/postgres/truncate";

--- a/src/lexer/statementFactory.ts
+++ b/src/lexer/statementFactory.ts
@@ -7,6 +7,7 @@ import {
   Drop,
   Truncate,
   Rename,
+  Do,
 } from "../barrel/statements";
 
 class StatementFactory {
@@ -21,6 +22,7 @@ class StatementFactory {
       alter: new Alter(),
       truncate: new Truncate(),
       rename: new Rename(),
+      do: new Do(),
     };
 
     if (Object.keys(statementMap).includes(statement)) {

--- a/src/lexer/statements/postgres/do.ts
+++ b/src/lexer/statements/postgres/do.ts
@@ -1,0 +1,36 @@
+import { Query } from "../../../reader/query";
+import { ILexer } from "../../interface";
+import { cleanUnquotedIdentifier } from "../../lexer";
+import { Keyword } from "../../../syntax/keywords";
+import { Types } from "../../types";
+import { Token } from "../../token";
+
+class Do implements ILexer {
+  public options: string[] = [];
+
+  public tokenise(query: Query): Query {
+    let lastToken = "";
+
+    query.lines.forEach((line) => {
+      line.content.split(" ").forEach((word) => {
+        let item = word.toLowerCase().trim();
+        if (item === Keyword.Do) {
+          line.tokens.push(new Token(Types.Keyword, item));
+        } else if (lastToken === Keyword.Do) {
+          item = cleanUnquotedIdentifier(item);
+
+          if (item.length > 0) {
+            line.tokens.push(
+              new Token(Types.Option, cleanUnquotedIdentifier(item))
+            );
+          }
+        }
+        lastToken = item;
+      });
+    });
+
+    return query;
+  }
+}
+
+export { Do };

--- a/src/syntax/keywords.ts
+++ b/src/syntax/keywords.ts
@@ -8,6 +8,7 @@ export enum Keyword {
   Declare = "declare",
   Delete = "delete",
   Delimiter = "delimiter",
+  Do = "do",
   Drop = "drop",
   Else = "else",
   End = "end",


### PR DESCRIPTION
# Summary

Adds support for PostgreSQL `DO` statements to the SQL linter. Previously, the linter would fail with "sql-lint was unable to lint the following query" errors when encountering `DO` anonymous code blocks, which are commonly used in PostgreSQL migration files.

# Background

The linter was throwing parsing errors on valid PostgreSQL migration files containing DO statements like:

```sql
  DO $$
  BEGIN
      IF NOT EXISTS (
          SELECT 1 FROM information_schema.table_constraints
          WHERE constraint_name = 'fk_example_constraint'
          AND table_name = 'example_table'
      ) THEN
          ALTER TABLE example_table ADD CONSTRAINT fk_example_constraint
          FOREIGN KEY (example_id) REFERENCES other_table(id);
      END IF;
  END $$;
```

 # Changes

  - Added `DO` keyword to `src/syntax/keywords.ts`
  - Created PostgreSQL `DO` statement handler at `src/lexer/statements/postgres/do.ts` following the same pattern as existing statement handlers
  - Updated statement factory in `src/lexer/statementFactory.ts` to recognize and handle do statements
  - Added barrel export in `src/barrel/statements.ts`

The implementation follows the existing codebase patterns and conventions used by other PostgreSQL statement handlers like ALTER, CREATE, etc.

# Test Plan

  - Built project successfully with `npm run build`
  - Tested with migration files containing `DO` statements - no more "unable to lint" errors
  - Verified the linter now recognizes `DO` as valid SQL syntax

# Impact

This resolves parsing failures for PostgreSQL migration files that use `DO` statements, allowing the SQL linter to process these files without errors.